### PR TITLE
Fix nextjs dev compile error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.next

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
   "dependencies": {
     "next": "^15.3.3",
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary
- remove `type: commonjs` from package.json so Next.js treats page files as ES modules
- ignore `.next` build directory

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848f2cf5784832a81e4db664fd019e7